### PR TITLE
smear is much more useful, if the returned value can be used later

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 module.exports = function smear (fn) {
   return function () {
     if (arguments.length === 1 && arguments[0] && arguments[0].length) {
-      fn.apply(this, arguments[0]);
+      return fn.apply(this, arguments[0]);
     } else {
       throw new Error('smear: expected an array as a lone parameter to spread!');
     }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,13 @@
   "version": "1.0.1",
   "description": "Spread an array parameter to a function",
   "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/wbinnssmith/smear.git"
+  },
+  "bugs": {
+    "url": "https://github.com/wbinnssmith/smear/issues"
+  },
   "scripts": {
     "test": "semistandard && node test.js"
   },

--- a/test.js
+++ b/test.js
@@ -53,3 +53,13 @@ test('passes through the context', function (t) {
     t.equal(seven, 7);
   }));
 });
+
+test('returns the value', function (t) {
+  return Promise.resolve([3, 5])
+      .then(smear(function (one, two) {
+        return one * two;
+      }))
+      .then(function (res) {
+        t.equal(res, 15);
+      });
+});


### PR DESCRIPTION
I also took the liberty to add repo links to pkg.json (so that a link to GH appears on the npm page for the pkg)
